### PR TITLE
Prevent asset generation workflow running on each PR

### DIFF
--- a/.github/workflows/integrate-pr.yaml
+++ b/.github/workflows/integrate-pr.yaml
@@ -3,7 +3,6 @@ name: Regenerate artifacts
 on:
   push:
     branches: [ "main" ]
-  pull_request:
 
 jobs:
   prepare:


### PR DESCRIPTION
This disables the workflow since the generation must commit to the repository and committing as part of PR would be a disaster and would not even commit files since we placed a protection for such cases.

Since generation and release are two separate workflows, it's fine to generate on main only